### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "10"
+  - "8"
   - "6"
-  - "5"
-  - "4"
 before_script:
   - npm install grunt-cli -g
 notifications:


### PR DESCRIPTION
Do not run against NodeJS v4 and v5.
Run against current NodeJS v6, v8 and v10 instead.